### PR TITLE
Import account key into daemon wallet before unlocking

### DIFF
--- a/src/main/kotlin/xyz/p42/Application.kt
+++ b/src/main/kotlin/xyz/p42/Application.kt
@@ -16,6 +16,7 @@ var graphQlPort = 8080
 var genesisLedgerPath: String = "N/A"
 var graphQlEndpoint: String = "N/A"
 var accountCommonPassword: String = "N/A"
+var walletStorePath: String? = null
 lateinit var accounts: List<Account>
 val accountsToBeReleased: MutableList<Account> = mutableListOf()
 
@@ -52,6 +53,10 @@ fun configureStrings(args: Array<String>) {
     args.getOrNull(0)?.trim() ?: throw IllegalArgumentException("Genesis ledger path is not provided")
   graphQlEndpoint = "http://localhost:${graphQlPort}/graphql"
   accountCommonPassword = args.getOrNull(3)?.trim() ?: ACCOUNT_COMMON_PASSWORD
+  walletStorePath = System.getenv("MINA_KEYS_PATH")
+  if (walletStorePath != null) {
+    logger.info("Wallet key files directory: $walletStorePath")
+  }
 }
 
 fun configureInMemoryAccounts() {

--- a/src/main/kotlin/xyz/p42/model/Model.kt
+++ b/src/main/kotlin/xyz/p42/model/Model.kt
@@ -53,6 +53,23 @@ data class UnlockAccountGraphQlResponse(
 )
 
 @Serializable
+data class ImportAccountResult(
+  val publicKey: String,
+  val alreadyImported: Boolean,
+  val success: Boolean
+)
+
+@Serializable
+data class ImportAccountWrapper(
+  val importAccount: ImportAccountResult
+)
+
+@Serializable
+data class ImportAccountGraphQlResponse(
+  val data: ImportAccountWrapper
+)
+
+@Serializable
 data class GraphQlPayload(
   val query: String,
   val variables: Map<String, String> = mapOf(),

--- a/src/main/kotlin/xyz/p42/utils/CommonUtils.kt
+++ b/src/main/kotlin/xyz/p42/utils/CommonUtils.kt
@@ -129,6 +129,17 @@ fun getUnlockAccountGraphQlQuery(publicKey: String) =
     }
     """.trimIndent()
 
+fun getImportAccountGraphQlQuery(path: String) =
+  """
+    mutation {
+      importAccount(password: "$accountCommonPassword", path: "$path") {
+        publicKey
+        alreadyImported
+        success
+      }
+    }
+    """.trimIndent()
+
 suspend fun releaseAccountAndGetNextIndex(): Int {
   if (accounts.isNotEmpty() && accountsToBeReleased.isNotEmpty()) {
     val publicKey = accountsToBeReleased.removeLast().pk

--- a/src/main/kotlin/xyz/p42/utils/NetworkUtils.kt
+++ b/src/main/kotlin/xyz/p42/utils/NetworkUtils.kt
@@ -4,13 +4,16 @@ package xyz.p42.utils
 import kotlinx.serialization.encodeToString
 import xyz.p42.graphQlEndpoint
 import xyz.p42.json
+import xyz.p42.walletStorePath
 import xyz.p42.model.Account
 import xyz.p42.model.GraphQlPayload
+import xyz.p42.model.ImportAccountGraphQlResponse
 import xyz.p42.model.LockAccountGraphQlResponse
 import xyz.p42.model.UnlockAccountGraphQlResponse
 import xyz.p42.model.VkGraphQlResponse
 import xyz.p42.properties.ENDPOINT_AVAILABILITY_CHECK_TIMEOUT
 import xyz.p42.properties.RESPONSE_STRING_LIMIT_CHARS
+import java.io.File
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -46,11 +49,34 @@ fun lockAccount(account: Account): String =
     return json.decodeFromString<LockAccountGraphQlResponse>(it).data.lockAccount.account.publicKey
   }
 
-fun unlockAccount(account: Account): String =
-  sendGraphQlQuery(getUnlockAccountGraphQlQuery(account.pk)).let {
-    checkNotNull(it) { "Account '${account.pk}' cannot be unlocked!" }
-    return json.decodeFromString<UnlockAccountGraphQlResponse>(it).data.unlockAccount.account.publicKey
+fun importAccountIfNeeded(account: Account) {
+  val keysDir = walletStorePath ?: return
+  val keyFile = File(keysDir, account.pk)
+  if (!keyFile.exists()) {
+    logger.info("Key file not found for account '${account.pk}' at ${keyFile.absolutePath}, skipping import")
+    return
   }
+  logger.info("Importing account '${account.pk}' from ${keyFile.absolutePath}...")
+  val response = sendGraphQlQuery(getImportAccountGraphQlQuery(keyFile.absolutePath))
+  if (response == null) {
+    logger.info("WARNING: importAccount returned null for '${account.pk}'")
+    return
+  }
+  val result = json.decodeFromString<ImportAccountGraphQlResponse>(response).data.importAccount
+  if (result.alreadyImported) {
+    logger.info("Account '${account.pk}' was already imported")
+  } else {
+    logger.info("Account '${account.pk}' imported successfully")
+  }
+}
+
+fun unlockAccount(account: Account): String {
+  importAccountIfNeeded(account)
+  return sendGraphQlQuery(getUnlockAccountGraphQlQuery(account.pk)).let {
+    checkNotNull(it) { "Account '${account.pk}' cannot be unlocked!" }
+    json.decodeFromString<UnlockAccountGraphQlResponse>(it).data.unlockAccount.account.publicKey
+  }
+}
 
 fun sendGraphQlQuery(query: String): String? =
   try {


### PR DESCRIPTION
## Summary

- When `unlockAccount=true` is passed to `/acquire-account`, the `unlockAccount` GraphQL mutation fails with "Could not find owned account associated with provided key" because the daemon's wallet store is empty
- The genesis account keys exist as encrypted files on disk (shipped in the `mina-lightnet-docker` image) but are never imported into the daemon
- This fix calls `importAccount` GraphQL mutation before `unlockAccount` when a matching key file is found on disk
- The key file directory is configured via the `MINA_KEYS_PATH` environment variable
- Without `MINA_KEYS_PATH` set, behavior is unchanged (backward compatible)

## Context

The `mina-lightnet-docker` image ships ~500 pre-encrypted key files in node wallet store directories (e.g. `nodes/whale_0/wallets/store/`). The daemon only loads keys that have been explicitly imported via `importAccount`. Currently, the accounts-manager skips the import step and calls `unlockAccount` directly, which fails because the key is not in the wallet.

This affects all users of daemon-side transaction signing (e.g. SDKs that use `sendPayment` mutation). Client-side signing (e.g. o1js `Lightnet.acquireKeyPair()`) is not affected since it never calls `unlockAccount`.

## How to use

In `mina-lightnet-docker`, set the environment variable when starting the accounts-manager:

```bash
MINA_KEYS_PATH=/root/.mina-network/mina-local-network-2-1-1/nodes/whale_0/wallets/store/ \
  accounts-manager /root/.mina-network/daemon.json 8181 3101 'naughty blue worm'
```

## Test plan

- [ ] Build with `./gradlew compileKotlin` (verified locally)
- [ ] Test with lightnet Docker container: `GET /acquire-account?unlockAccount=true` should return `{pk, sk}` instead of 500 error
- [ ] Verify backward compatibility: without `MINA_KEYS_PATH`, existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)